### PR TITLE
Use node16 in Github Actions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,7 +6,7 @@ jobs:
   check-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "12"

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "16"
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: git diff --exit-code -- dist/

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - run: npm install
       - run: npm run build
       - run: git diff --exit-code -- dist/

--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone PR branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create release
         uses: elisa-actions/pr-release@v1
         with:


### PR DESCRIPTION
- use node16 in Github Actions as node12 is deprecated
