### PR TITLE
fix: provide image identifier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,4 +14,4 @@ inputs:
     default: false
 runs:
   using: "docker"
-  main: "Dockerfile"
+  image: "Dockerfile"


### PR DESCRIPTION
Provide docker image instead of pointing to main runner