### PR TITLE
Use main as destination branch for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,3 @@ updates:
       include: "scope"
     labels: []
     open-pull-requests-limit: 10
-    target-branch: deps


### PR DESCRIPTION
For easier dependency updates